### PR TITLE
Offline tests

### DIFF
--- a/commands/add.js
+++ b/commands/add.js
@@ -1,7 +1,7 @@
 var async = require('async');
 
 module.exports = function(app) {
-  app.command('add ([\w\-]+) ([^\\s]+)', function(bot, message) {
+  app.command('add ([^\\s]+) ([^\\s]+)', function(bot, message) {
     var resourceType = message.match[1];
     var resourceName = message.match[2];
 

--- a/offline.js
+++ b/offline.js
@@ -1,0 +1,79 @@
+var botkit = require('./lib/Botkit');
+var logger = console;
+
+var SLACK_USERNAME = process.env.BOT_NAME || 'resourcebot';
+var PACKAGE_INFORMATION = require('./package.json');
+var PACKAGE_VERSION = PACKAGE_INFORMATION.version;
+
+var LISTEN_ON = [
+    'direct_message',
+    'direct_mention',
+    'mention'
+];
+
+var mongoConfig = {
+    mongo_uri: process.env.MONGO_URI
+};
+
+var slackConfig = {
+    token: process.env.SLACK_TOKEN
+};
+
+var controller = botkit.slackbot({
+    debug: true,
+    logger: logger
+});
+
+var bot = controller.spawn(slackConfig);
+var app = {
+    version: PACKAGE_VERSION,
+    LISTEN_ON: LISTEN_ON,
+    slack_username: SLACK_USERNAME,
+    mongo_config: mongoConfig,
+    slack_config: slackConfig,
+    controller: controller,
+    bot: bot,
+    command: function(commandDescription, func) {
+        'use strict';
+        return this.controller.hears(commandDescription, LISTEN_ON, func);
+    }
+};
+
+require('./commands/help')(app);
+require('./commands/list')(app);
+require('./commands/add')(app);
+require('./commands/remove')(app);
+require('./commands/claim')(app);
+require('./commands/release')(app);
+
+// Exit handling
+var exitHandler = function(options, err) {
+    if (options.cleanup) {
+        logger.info('in exitHandler(), process.exit()');
+    }
+
+    if (err) {
+        logger.error(err.stack);
+    }
+
+    if (options.exit) {
+        logger.info('Process exiting');
+        process.exit();
+    }
+};
+
+process.on('exit', exitHandler.bind(null, {
+    cleanup: true
+}));
+
+// Catch Ctrl-c
+process.on('SIGINT', exitHandler.bind(null, {
+    exit: true
+}));
+
+// Catch uncaught exceptions
+process.on('uncaughtException', exitHandler.bind(null, {
+    exit:true
+}));
+
+module.exports = app;

--- a/package.json
+++ b/package.json
@@ -26,7 +26,8 @@
     "tape": "^4.2.2"
   },
   "scripts": {
-    "test": "node test/*-test.js | tap-spec"
+    "test": "node test/*-test.js | tap-spec",
+    "fh": "node test/fh.js | tap-spec"
   },
   "repository": {
     "type": "git",

--- a/test/fh.js
+++ b/test/fh.js
@@ -1,0 +1,8 @@
+var test = require('tape')
+var app = require('../offline');
+
+test('add', function (t) {
+    const bot = {identity: {id: 'bot'}};
+    const message = {text: '<@bot> add resource_type resource_name', type: 'message', channel: 'bot'};
+    app.controller.events['message_received'][0](bot, message)
+})


### PR DESCRIPTION
This PR fixes the regex for the add command, and also introduces a somewhat _working_ offline tests.

The tests currently work up until the moment it tries to access mongodb, then it will fail. Nevertheless I've included them as an example skeleton for triggering commands without going through slack.